### PR TITLE
Fix typo in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ A [Homebrew](https://brew.sh/) tap for the simple FreeBSD-style editor, ee, a.k.
 
 ## Install 
 
-To install this tape, simply run:
+To install this tap, simply run:
 
     brew install clearpathdigital/homebrew-ee/ee
 


### PR DESCRIPTION
Was exploring the use of the EE editor in FreeBSD and tried to use homebrew to install.  Was pointed to your tap to do the install and was very appreciative!  Browsed the README and found this small typo and wanted to give back with this slight correction.  Cheers!